### PR TITLE
Mac Homebrew Fix

### DIFF
--- a/lib/image_science.rb
+++ b/lib/image_science.rb
@@ -88,9 +88,11 @@ class ImageScience
   end
 
   inline do |builder|
-    if test ?d, "/opt/local" then
-      builder.add_compile_flags "-I/opt/local/include"
-      builder.add_link_flags "-L/opt/local/lib"
+    ["/opt/local", "/usr/local"].each do |library_directory|
+      if test ?d, "#{library_directory}/include" then
+        builder.add_compile_flags "-I#{library_directory}/include"
+        builder.add_link_flags "-L#{library_directory}/lib"
+      end
     end
 
     builder.add_link_flags "-lfreeimage"


### PR DESCRIPTION
Originally, this code checked for the existence of "/opt/local" and then, if it exists, it adds the library paths for "/opt/local/include" and /lib. My system (with Homebrew installed) had an "/opt/local" folder... but no "/include" or "lib" subfolders. My application needed "/usr/local".

More information of a similar error can be found here: 
http://librelist.com/browser//homebrew/2010/3/13/homebrew-problems-with-freeimage-image-science/#3b296773ed5afe8c2c3ee6e0a1928aef

I now have it testing for two locations and testing more specifically for "/opt/local/include" and "/usr/local/include" respectively.
