### PR TITLE
Don't remove the user's Inline directory to run the tests — And don't assume a home directory

### DIFF
--- a/test/test_image_science.rb
+++ b/test/test_image_science.rb
@@ -1,10 +1,16 @@
-dir = File.expand_path "~/.ruby_inline"
-if test ?d, dir then
-  require 'fileutils'
-  puts "nuking #{dir}"
-  # force removal, Windoze is bitching at me, something to hunt later...
-  FileUtils.rm_r dir, :force => true
-end
+# instead of using Inline's regular directory in the user's home, use
+# a temporary directory
+#
+# dir = File.expand_path "~/.ruby_inline"
+# if test ?d, dir then
+#   require 'fileutils'
+#   puts "nuking #{dir}"
+#   # force removal, Windoze is bitching at me, something to hunt later...
+#   FileUtils.rm_r dir, :force => true
+# end
+
+require 'tmpdir'
+ENV['INLINEDIR'] = Dir.mktmpdir
 
 require 'rubygems'
 require 'minitest/unit'


### PR DESCRIPTION
(Redirecting the issue to Github from Rubyforge issue #29544)

When starting test_image_science.rb, you wipe the user's ~/.ruby_inline. This, besides having the potential to be bothersome
for users, leads to a failure when the home directory is not defined or does not exist. We hit this bug in the Debian
buildd network, as in the autobuilder environments no home directory exists:

  http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=652802

The pull request defines ENV['INLINEDIR'] to a disposable temporary directory.

Thanks,
