### PR TITLE
Thumbnail rounding seattle

### DIFF
--- a/lib/image_science.rb
+++ b/lib/image_science.rb
@@ -60,7 +60,7 @@ class ImageScience
     w, h = width, height
     scale = size.to_f / (w > h ? w : h)
 
-    self.resize((w * scale).to_i, (h * scale).to_i) do |image|
+    self.resize((w * scale).round, (h * scale).round) do |image|
       yield image
     end
   end

--- a/test/test_image_science.rb
+++ b/test/test_image_science.rb
@@ -157,4 +157,21 @@ class TestImageScience < MiniTest::Unit::TestCase
 
     refute File.exists?(@tmppath)
   end
+
+  def test_thumbnail
+    ImageScience.with_image @path do |img|
+      img.thumbnail(29) do |thumb|
+        assert thumb.save(@tmppath)
+      end
+    end
+
+    assert File.exists?(@tmppath)
+
+    ImageScience.with_image @tmppath do |img|
+      assert_kind_of ImageScience, img
+      assert_equal 29, img.height
+      assert_equal 29, img.width
+    end
+  end
+
 end


### PR DESCRIPTION
Given a particular image size, thumbnail(100) would occasionally produce an image with a width/height of 99.  This was due to float precision giving us a target size of 99.9999.

How about rounding the target size, like in the attached commit?
