### PR TITLE
Add rotate method.

### DIFF
--- a/lib/image_science.rb
+++ b/lib/image_science.rb
@@ -53,6 +53,11 @@ class ImageScience
   # :method: resize
 
   ##
+  # Rotate the image to +angle+. Limited to 45 degree skewing only.
+  #
+  # :method: rotate
+
+  ##
   # Creates a proportional thumbnail of the image scaled so its longest
   # edge is resized to +size+ and yields the new image.
 
@@ -268,6 +273,20 @@ class ImageScience
         if (h <= 0) rb_raise(rb_eArgError, "Height <= 0");
         GET_BITMAP(bitmap);
         image = FreeImage_Rescale(bitmap, w, h, FILTER_CATMULLROM);
+        if (image) {
+          copy_icc_profile(self, bitmap, image);
+          return wrap_and_yield(image, self, 0);
+        }
+        return Qnil;
+      }
+    END
+
+    builder.c <<-"END"
+      VALUE rotate(int angle) {
+        FIBITMAP *bitmap, *image;
+        if ((angle % 45) != 0) rb_raise(rb_eArgError, "Angle must be 45 degree skew");
+        GET_BITMAP(bitmap);
+        image = FreeImage_RotateClassic(bitmap, angle);
         if (image) {
           copy_icc_profile(self, bitmap, image);
           return wrap_and_yield(image, self, 0);

--- a/test/test_image_science.rb
+++ b/test/test_image_science.rb
@@ -188,4 +188,23 @@ class TestImageScience < Minitest::Test
       assert_equal 38, img.width
     end
   end
+
+  def test_rotate
+    ImageScience.with_image "test/portrait.jpg" do |image|
+      image.rotate 90 do |img|
+        assert_equal 50, img.width
+        assert_equal 38, img.height
+      end
+    end
+  end
+
+  def test_rotate_not_45
+    e = assert_raises ArgumentError do
+      ImageScience.with_image "test/portrait.jpg" do |image|
+        image.rotate 44
+      end
+    end
+
+    assert_equal 'Angle must be 45 degree skew', e.message
+  end
 end


### PR DESCRIPTION
We have some images being uploaded where visually they are correct, but the orientation flag says they need to be rotated, messing with the auto rotate. One idea we have is to provide a way for QA to manually rotate images with complaints.

I did a lot of copying and pasting, so appreciate you looking at this.

unknowns:

* FreeImage_RotateClassic looks deprecated, but when I removed "Classic" I got errors running the tests, so I left it.
* the c method argument for angle is a double, should I make it a double here as well?
* I am not sure how to word the argument error message.
* angle degree checking in the c code is done using an fmod method, is what I have ok?