### PR TITLE
Replace rubyforge urls

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -10,7 +10,7 @@ ImageScience is a clean and happy Ruby library that generates
 thumbnails -- and kicks the living crap out of RMagick. Oh, and it
 doesn't leak memory like a sieve. :)
 
-For more information including build steps, see http://seattlerb.rubyforge.org/
+For more information, see http://docs.seattlerb.org/image_science
 
 == FEATURES/PROBLEMS:
 
@@ -39,7 +39,7 @@ For more information including build steps, see http://seattlerb.rubyforge.org/
 
 * Download and install FreeImage. See notes at url above.
 * sudo gem install -y image_science
-* see http://seattlerb.rubyforge.org/ImageScience.html for more info.
+* see http://docs.seattlerb.org/image_science for more info.
 
 == LICENSE:
 

--- a/lib/image_science.rb
+++ b/lib/image_science.rb
@@ -7,8 +7,8 @@ require 'inline'
 # Provides a clean and simple API to generate thumbnails using
 # FreeImage as the underlying mechanism.
 #
-# For more information or if you have build issues with FreeImage, see
-# http://seattlerb.rubyforge.org/ImageScience.html
+# For more information, see
+# http://docs.seattlerb.org/image_science
 
 class ImageScience
   VERSION = '1.3.2'


### PR DESCRIPTION
non-code changes to update old RubyForge URLs in documentation (probably relevant to Issue #26 also)